### PR TITLE
fix:更改notice-bar关闭函数名称错误的问题

### DIFF
--- a/src/notice-bar/index.wxml
+++ b/src/notice-bar/index.wxml
@@ -13,5 +13,5 @@
     </view>
   </view>
   <l-icon wx:if="{{ endIconName && !close }}" size="24" color="#3683D6" class="l-noticebar-operation" name="{{ endIconName }}" icon-style="{{ endIconStyle }}" bindtap="onIconTap"  />
-  <l-icon wx:if="{{close}}" class="l-noticebar-operation" name="close" size="24" color="#3683D6" bindtap="onClsoe"/>
+  <l-icon wx:if="{{close}}" class="l-noticebar-operation" name="close" size="24" color="#3683D6" bindtap="onClose"/>
 </view>


### PR DESCRIPTION
fix:更改notice-bar关闭函数名称错误