### PR TITLE
为 searchBar 添加 type 属性

### DIFF
--- a/src/search-bar/index.js
+++ b/src/search-bar/index.js
@@ -11,6 +11,10 @@ Component({
     'l-cancel-class'
   ],
   properties: {
+    type: {
+      type: String,
+      value: 'search'
+    },
     placeholder: String,
     cancelText: {
       type: String,


### PR DESCRIPTION
input 聚焦后键盘的确认文本应该是：“搜索”
而且在 wxml 中已经用到了 type 但是在组件属性中却没有