### PR TITLE
fix(popup): 修复隐藏popup中textarea内容依旧显示的问题

### DIFF
--- a/src/popup/index.less
+++ b/src/popup/index.less
@@ -1,5 +1,5 @@
 .container-popup {
-  visibility: hidden;
+  display: none;
   position: fixed;
   top: 0;
   left: 0;
@@ -8,7 +8,7 @@
 }
 
 .popup-show {
-  visibility: visible;
+  display: block;
 }
 
 .popup-show .container-bg {


### PR DESCRIPTION
问题描述:
popup中如果有textarea时 即使popup隐藏
textarea的文字内容依旧会显示

尝试过传入z-index和opacity均未完美解决