### PR TITLE
fix:修复gird组件内容不能正常显示的bug

### DIFF
--- a/dist/grid-item/index.js
+++ b/dist/grid-item/index.js
@@ -18,6 +18,18 @@ Component({
   attached() {
 
   },
+  observers: {
+    'key': function() {
+      const parent = this.getRelationNodes('../grid/index')[0];
+      if (parent) {
+        parent.setData({
+          gridItems: [],
+          childNum: 0
+        });
+        parent.initGrids();
+      }
+    }
+  },
 
   lifetimes: {
     show() {

--- a/examples/dist/grid-item/index.js
+++ b/examples/dist/grid-item/index.js
@@ -18,6 +18,18 @@ Component({
   attached() {
 
   },
+  observers: {
+    'key': function() {
+      const parent = this.getRelationNodes('../grid/index')[0];
+      if (parent) {
+        parent.setData({
+          gridItems: [],
+          childNum: 0
+        });
+        parent.initGrids();
+      }
+    }
+  },
 
   lifetimes: {
     show() {

--- a/src/grid-item/index.js
+++ b/src/grid-item/index.js
@@ -18,6 +18,18 @@ Component({
   attached() {
 
   },
+  observers: {
+    'key': function() {
+      const parent = this.getRelationNodes('../grid/index')[0];
+      if (parent) {
+        parent.setData({
+          gridItems: [],
+          childNum: 0
+        });
+        parent.initGrids();
+      }
+    }
+  },
 
   lifetimes: {
     show() {


### PR DESCRIPTION
fix:修复gird组件 以id为key值时 当切换gird数据的前后gird-item数量一致时不能显示gird内容的bug