### PR TITLE
feat:新增两个外部样式类 (# 599)

### DIFF
--- a/dist/textarea/index.js
+++ b/dist/textarea/index.js
@@ -6,7 +6,7 @@ Component({
    * 组件的属性列表
    */
   behaviors: ['wx://form-field', rules],
-  externalClasses: ['l-class', 'l-error-text', 'l-error-text-class'],
+  externalClasses: ['l-class', 'l-error-text', 'l-error-text-class', 'l-textarea-class', 'l-border-class'],
   properties: {
     // 占位文本
     placeholder: {

--- a/dist/textarea/index.wxml
+++ b/dist/textarea/index.wxml
@@ -1,10 +1,10 @@
 <!--  input/input.wxml -->
 <label class='form-item {{disabled? "disabled": ""}}   l-class '>
-  <view class='default-border {{border? "border": ""}}'>
+  <view class='default-border {{border? "border": ""}} l-border-class'>
     <view class='mask' wx:if="{{disabled}}"></view>
     <!-- 小程序表单组件 -->
     <textarea
-      class=" textarea"
+      class=" textarea l-textarea-class"
       type="{{type}}"
       value="{{ value }}"
       password="{{type==='password'}}"

--- a/examples/dist/textarea/index.js
+++ b/examples/dist/textarea/index.js
@@ -6,7 +6,7 @@ Component({
    * 组件的属性列表
    */
   behaviors: ['wx://form-field', rules],
-  externalClasses: ['l-class', 'l-error-text', 'l-error-text-class'],
+  externalClasses: ['l-class', 'l-error-text', 'l-error-text-class', 'l-textarea-class', 'l-border-class'],
   properties: {
     // 占位文本
     placeholder: {

--- a/examples/dist/textarea/index.wxml
+++ b/examples/dist/textarea/index.wxml
@@ -1,10 +1,10 @@
 <!--  input/input.wxml -->
 <label class='form-item {{disabled? "disabled": ""}}   l-class '>
-  <view class='default-border {{border? "border": ""}}'>
+  <view class='default-border {{border? "border": ""}} l-border-class'>
     <view class='mask' wx:if="{{disabled}}"></view>
     <!-- 小程序表单组件 -->
     <textarea
-      class=" textarea"
+      class=" textarea l-textarea-class"
       type="{{type}}"
       value="{{ value }}"
       password="{{type==='password'}}"

--- a/src/textarea/index.js
+++ b/src/textarea/index.js
@@ -6,7 +6,7 @@ Component({
    * 组件的属性列表
    */
   behaviors: ['wx://form-field', rules],
-  externalClasses: ['l-class', 'l-error-text', 'l-error-text-class'],
+  externalClasses: ['l-class', 'l-error-text', 'l-error-text-class', 'l-textarea-class', 'l-border-class'],
   properties: {
     // 占位文本
     placeholder: {

--- a/src/textarea/index.wxml
+++ b/src/textarea/index.wxml
@@ -1,10 +1,10 @@
 <!--  input/input.wxml -->
 <label class='form-item {{disabled? "disabled": ""}}   l-class '>
-  <view class='default-border {{border? "border": ""}}'>
+  <view class='default-border {{border? "border": ""}} l-border-class'>
     <view class='mask' wx:if="{{disabled}}"></view>
     <!-- 小程序表单组件 -->
     <textarea
-      class=" textarea"
+      class=" textarea l-textarea-class"
       type="{{type}}"
       value="{{ value }}"
       password="{{type==='password'}}"


### PR DESCRIPTION
l-textarea-class覆盖文本域的样式
l-border-class覆盖文本+字数提示的外部样式