### PR TITLE
fix(action_sheet): 修复操作菜单报错问题

### DIFF
--- a/dist/action-sheet/index.wxml
+++ b/dist/action-sheet/index.wxml
@@ -4,16 +4,16 @@
             {{ title }}
         </view>
         <view wx:for="{{ itemList }}" wx:key="name" hover-class="{{isHover?'list-hover':''}}">
-            <l-button bind:lintap="handleClickItem" data-index="{{ index }}" data-item="{{ item }}" open-type="{{ item.openType }}" icon="{{ item.icon }}" type="ghost" size="large" special="{{true}}" long>
+            <l-button bind:lintap="handleClickItem" data-index="{{ index }}" data-item="{{ item }}" open-type="{{ item.openType }}" icon="{{ item.icon }}" type="default" size="large" special="{{true}}" long>
                 <view style="{{ item.color ? 'color: ' + item.color : '' }}" class="l-item-button l-class-item l-item-class {{item.image || item.icon ? 'l-image-button':''}}">
                     <image wx:if="{{item.image}}" class="l-button-image" src="{{item.image}}" style="{{item.imageStyle}}"/>
-                    <l-icon wx:elif="{{ item.icon }}" name="{{ item.icon }}" l-class="l-item-button" size="{{ item.iconSize }}" color="{{item.iconColor?item.iconColor:item.color}}"></l-icon>  
+                    <l-icon wx:elif="{{ item.icon }}" name="{{ item.icon }}" l-class="l-item-button" size="{{ item.iconSize }}" color="{{item.iconColor?item.iconColor:item.color}}"></l-icon>
                     <text class="l-button-text">{{ item.name }}</text>
                 </view>
             </l-button>
         </view>
         <view class="l-cancel l-class-cancel l-cancel-class {{isIphoneX ? 'l-cancel-x':''}}" wx:if="{{ showCancel }}" hover-class="{{isHover?'list-hover':''}}">
-            <l-button type="ghost" size="large" long="true" bind:lintap="handleClickCancel" special="{{true}}">
+            <l-button type="default" size="large" long="true" bind:lintap="handleClickCancel" special="{{true}}">
                 <view class="l-item-button l-cancel-button">{{ cancelText }}</view>
             </l-button>
         </view>

--- a/examples/dist/action-sheet/index.wxml
+++ b/examples/dist/action-sheet/index.wxml
@@ -4,21 +4,21 @@
             {{ title }}
         </view>
         <view wx:for="{{ itemList }}" wx:key="name" hover-class="{{isHover?'list-hover':''}}">
-            <l-button bind:lintap="handleClickItem" data-index="{{ index }}" data-item="{{ item }}" open-type="{{ item.openType }}" icon="{{ item.icon }}" type="ghost" size="large" special="{{true}}" long>
+            <l-button bind:lintap="handleClickItem" data-index="{{ index }}" data-item="{{ item }}" open-type="{{ item.openType }}" icon="{{ item.icon }}" type="default" size="large" special="{{true}}" long>
                 <view style="{{ item.color ? 'color: ' + item.color : '' }}" class="l-item-button l-class-item l-item-class {{item.image || item.icon ? 'l-image-button':''}}">
                     <image wx:if="{{item.image}}" class="l-button-image" src="{{item.image}}" style="{{item.imageStyle}}"/>
-                    <l-icon 
-                        wx:elif="{{ item.icon }}" 
-                        name="{{ item.icon }}" 
+                    <l-icon
+                        wx:elif="{{ item.icon }}"
+                        name="{{ item.icon }}"
                         l-class="l-item-button"
                         size="{{ item.iconSize }}"
-                        color="{{item.iconColor?item.iconColor:item.color}}"></l-icon>  
+                        color="{{item.iconColor?item.iconColor:item.color}}"></l-icon>
                     <text class="l-button-text">{{ item.name }}</text>
                 </view>
             </l-button>
         </view>
         <view class="l-cancel l-class-cancel l-cancel-class {{isIphoneX ? 'l-cancel-x':''}}" wx:if="{{ showCancel }}" hover-class="{{isHover?'list-hover':''}}">
-            <l-button type="ghost" size="large" long="true" bind:lintap="handleClickCancel" special="{{true}}">
+            <l-button type="default" size="large" long="true" bind:lintap="handleClickCancel" special="{{true}}">
                 <view class="l-item-button l-cancel-button">{{ cancelText }}</view>
             </l-button>
         </view>

--- a/src/action-sheet/index.wxml
+++ b/src/action-sheet/index.wxml
@@ -4,21 +4,21 @@
             {{ title }}
         </view>
         <view wx:for="{{ itemList }}" wx:key="name" hover-class="{{isHover?'list-hover':''}}">
-            <l-button bind:lintap="handleClickItem" data-index="{{ index }}" data-item="{{ item }}" open-type="{{ item.openType }}" icon="{{ item.icon }}" type="ghost" size="large" special="{{true}}" long>
+            <l-button bind:lintap="handleClickItem" data-index="{{ index }}" data-item="{{ item }}" open-type="{{ item.openType }}" icon="{{ item.icon }}" type="default" size="large" special="{{true}}" long>
                 <view style="{{ item.color ? 'color: ' + item.color : '' }}" class="l-item-button l-class-item l-item-class {{item.image || item.icon ? 'l-image-button':''}}">
                     <image wx:if="{{item.image}}" class="l-button-image" src="{{item.image}}" style="{{item.imageStyle}}"/>
-                    <l-icon 
-                        wx:elif="{{ item.icon }}" 
-                        name="{{ item.icon }}" 
+                    <l-icon
+                        wx:elif="{{ item.icon }}"
+                        name="{{ item.icon }}"
                         l-class="l-item-button"
                         size="{{ item.iconSize }}"
-                        color="{{item.iconColor?item.iconColor:item.color}}"></l-icon>  
+                        color="{{item.iconColor?item.iconColor:item.color}}"></l-icon>
                     <text class="l-button-text">{{ item.name }}</text>
                 </view>
             </l-button>
         </view>
         <view class="l-cancel l-class-cancel l-cancel-class {{isIphoneX ? 'l-cancel-x':''}}" wx:if="{{ showCancel }}" hover-class="{{isHover?'list-hover':''}}">
-            <l-button type="ghost" size="large" long="true" bind:lintap="handleClickCancel" special="{{true}}">
+            <l-button type="default" size="large" long="true" bind:lintap="handleClickCancel" special="{{true}}">
                 <view class="l-item-button l-cancel-button">{{ cancelText }}</view>
             </l-button>
         </view>


### PR DESCRIPTION
操作菜单中的按钮类型使用的是ghost，但按钮没有这个类型，新加入的参数校验机制会抛出错误，所以将其改为了default