### PR TITLE
删除 Example 示例小程序 app.json 中的 navigateToMiniProgramAppIdList 字段

### DIFF
--- a/examples/app.json
+++ b/examples/app.json
@@ -11,9 +11,6 @@
     "navigationBarTitleText": "Lin UI",
     "navigationBarTextStyle": "black"
   },
-  "navigateToMiniProgramAppIdList": [
-    "wxb05fa7b69aa7e5b7"
-  ],
   "tabBar": {
     "color": "#bbbbbb",
     "selectedColor": "#3963BC",


### PR DESCRIPTION
从2020年4月28日起，无需再设置navigateToMiniProgramAppIdList
详见：http://t.cn/AipuKjsh