### PR TITLE
修复 Input 组件 width 属性无效的问题

### DIFF
--- a/src/input/index.js
+++ b/src/input/index.js
@@ -48,8 +48,8 @@ Component({
     },
     // 表单项的宽度，单位rpx
     width: {
-      type: Number,
-      value: 750
+      type: String,
+      value: 'auto'
     },
     // 表单项标题部分的宽度，单位rpx
     labelWidth: {

--- a/src/input/index.less
+++ b/src/input/index.less
@@ -4,9 +4,7 @@
   position: relative;
   font-size: 28rpx;
   color: #333;
-  width: 750rpx;
   height: 88rpx;
-  // background: #f6f6f6;
   display: flex;
   flex-direction: row;
   align-items: center;

--- a/src/input/index.wxml
+++ b/src/input/index.wxml
@@ -1,7 +1,7 @@
 <!--  input/input.wxml -->
 <label
   class='form-item {{disabled? "disabled": ""}} l-class form-item-{{labelLayout}}'
-  style="widthform-item:{{width}}rpx">
+  style="width:{{width}}rpx">
   <view class='mask' wx:if="{{disabled}}"></view>
   <view class='row' hidden="{{ showRow ? '' : 'hidden' }}" style="width:{{width}}rpx;"></view>
   <view wx:if="{{label && !labelCustom}}" hidden="{{hideLabel}}" class='form-label l-label-class form-label-{{labelLayout}}' style='{{labelLayout !== "top" ? "width:"+ labelWidth+ "rpx;" : "" }} height:{{labelLayout=== "top" ? labelWidth + "rpx" : "" }}'>


### PR DESCRIPTION
由于width属性名写错，导致width不生效
由于属性设置为 750rpx，导致 Input 样式在很多情况下不正确

close #860,#744