### PR TITLE
修改 Dialog 组件 confirm 按钮和 cancel 按钮上边框定义位置

### DIFF
--- a/src/dialog/index.less
+++ b/src/dialog/index.less
@@ -38,7 +38,6 @@
   flex-direction: row;
   justify-content: space-between;
   align-items: center;
-  border-top: 2rpx solid rgba(243,243,243,1);
 }
 
 .dialog-btn-cancel{
@@ -49,7 +48,8 @@
   display: flex;
   flex-direction: row;
   align-items: center;
-  justify-content: center
+  justify-content: center;
+  border-top: 2rpx solid rgba(243,243,243,1);
 }
 
 .dialog-btn-confirm{
@@ -60,7 +60,8 @@
   display: flex;
   flex-direction: row;
   align-items: center;
-  justify-content: center
+  justify-content: center;
+  border-top: 2rpx solid rgba(243,243,243,1);
 }
 
 .active{


### PR DESCRIPTION
confirm 按钮和 cancel 按钮的上边框原本是定义在 dialog-btn-group 样式中
但是该样式没有对应的外部样式类，无法修改边框颜色
现将上边框定义移动到 dialog-btn-confirm 和 dialog-btn-cancel 中
可以通过外部样式类 l-confirm-class 和 l-cancel-class 修改边框颜色

close #600