### PR TITLE
修复 Album 组件图片无法正常显示的问题

### DIFF
--- a/src/album/index.js
+++ b/src/album/index.js
@@ -82,6 +82,12 @@ Component({
     },
   },
 
+  observers: {
+    'urls': function () {
+      this.preview();
+    }
+  },
+
   /**
    * 组件的方法列表
    */


### PR DESCRIPTION
当 urls 初始化为空数组，并在后期修改为字符串数组时
组件无法显示出图片，因为默认将空数组识别为对象数组

该 commit 增加数据监听器，每次设置 urls 都将重新判断类型，保证图片正常显示

close #921