### PR TITLE
修复 Form 组件重置按钮无效问题

### DIFF
--- a/src/form/index.wxml
+++ b/src/form/index.wxml
@@ -2,10 +2,10 @@
     <slot />
 </view>
 <view class="l-form-btn-class">
-    <view class="l-form-submit-class" mut-bind:tap="submit">
+    <view class="l-form-submit-class" capture-bind:tap="submit">
         <slot name="submit"/>
     </view>
-    <view class="l-form-reset-class" mut-bind:tap="reset">
+    <view class="l-form-reset-class" capture-bind:tap="reset">
         <slot name="reset"/>
     </view>
 </view>


### PR DESCRIPTION
将 form 组件插槽上级绑定事件的 mut-bind 更改为 capture-bind

close #1028
