### PR TITLE
修复 Avatar 组件使用 Icon 属性时容器宽高不正确问题

### DIFF
--- a/src/avatar/index.wxml
+++ b/src/avatar/index.wxml
@@ -1,6 +1,6 @@
 
 <view class="l-avatar {{text||_isHaveUserNickName?'l-placement-'+placement:''}}" mut-bind:tap="tapAvatar">
-    <view class="l-avatar-image {{shape?'l-'+shape:''}} l-class" wx:if="{{_isHaveUserAvatarUrl||icon||src}}" style="width:{{size}}rpx;height:{{size}}rpx">
+    <view class="l-avatar-image {{shape?'l-'+shape:''}} l-class" wx:if="{{_isHaveUserAvatarUrl||icon||src}}" style="width:{{size}}rpx;height:{{size}}rpx;min-width:{{size}}rpx;min-height:{{size}}rpx;">
         <open-data class="open-data" wx:if="{{_isHaveUserAvatarUrl}}" type="userAvatarUrl" />
         <l-icon wx:elif="{{icon}}" size="{{iconSize || size*0.6}}" color="{{iconColor||'#ffffff'}}" name="{{icon}}" />
         <image wx:elif="{{src}}" src="{{src}}" mode="{{mode}}" style="width:{{size}}rpx;height:{{size}}rpx" />


### PR DESCRIPTION
当 text 属性存在，使用 Icon 展示，且 placement 为 top 或 bottom 时，宽高显示不正确（自定义图片时不会出现）

close #1043