### PR TITLE
Form 组件修改 label-width 默认值

### DIFF
--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -63,6 +63,7 @@ module.exports = {
         'Rules',
         'Rate',
         'Form',
+        'FormItem',
         'Price',
         'Counter',
         'SearchBar',

--- a/src/form-item/index.js
+++ b/src/form-item/index.js
@@ -36,7 +36,7 @@ Component({
     // label宽度
     labelWidth: {
       type: String,
-      value: '200rpx'
+      value: 'auto'
     },
     labelSlot: {
       type: Boolean,


### PR DESCRIPTION
修改原因：label-width 默认值太大
修改结果：label-width 默认值：200 px => auto

BREAKING CHANGE: label-width 默认值由 200 px 改为 auto