### PR TITLE
优化 ImageClipper 组件 CSS 选择器名称

### DIFF
--- a/src/image-clipper-tools/index.less
+++ b/src/image-clipper-tools/index.less
@@ -12,7 +12,7 @@
             display: flex;
             align-items: center;
         }
-        switch {
+        .tools-switch {
             transform: scale(0.7);
         }
     }

--- a/src/image-clipper-tools/index.wxml
+++ b/src/image-clipper-tools/index.wxml
@@ -2,27 +2,27 @@
     <view class="tools-form">
         <view wx:if="{{lockWidth}}">
             锁定裁剪框宽
-            <switch model:checked="{{lockWidthValue}}" color="{{formColor}}" bindchange="bindSwitchChange" data-type="lockWidth" />
+            <switch model:checked="{{lockWidthValue}}" color="{{formColor}}" bindchange="bindSwitchChange" data-type="lockWidth" class="tools-switch" />
         </view>
         <view wx:if="{{lockHeight}}">
             锁定裁剪框高
-            <switch model:checked="{{lockHeightValue}}" color="{{formColor}}" bindchange="bindSwitchChange" data-type="lockHeight" />
+            <switch model:checked="{{lockHeightValue}}" color="{{formColor}}" bindchange="bindSwitchChange" data-type="lockHeight" class="tools-switch" />
         </view>
         <view wx:if="{{lockRatio}}">
             锁定裁剪框比例
-            <switch model:checked="{{lockRatioValue}}" color="{{formColor}}" bindchange="bindSwitchChange" data-type="lockRatio" />
+            <switch model:checked="{{lockRatioValue}}" color="{{formColor}}" bindchange="bindSwitchChange" data-type="lockRatio" class="tools-switch" />
         </view>
          <view wx:if="{{limitMove}}">
             限制移动范围
-            <switch model:checked="{{limitMoveValue}}" color="{{formColor}}" bindchange="bindSwitchChange" data-type="limitMove" />
+            <switch model:checked="{{limitMoveValue}}" color="{{formColor}}" bindchange="bindSwitchChange" data-type="limitMove" class="tools-switch" />
         </view>
         <view wx:if="{{disableScale}}">
             禁止缩放
-            <switch model:checked="{{disableScaleValue}}" color="{{formColor}}" bindchange="bindSwitchChange" data-type="disableScale" />
+            <switch model:checked="{{disableScaleValue}}" color="{{formColor}}" bindchange="bindSwitchChange" data-type="disableScale" class="tools-switch" />
         </view>
         <view wx:if="{{disableRotate}}">
             禁止旋转
-            <switch model:checked="{{disableRotateValue}}" color="{{formColor}}" bindchange="bindSwitchChange" data-type="disableRotate" />
+            <switch model:checked="{{disableRotateValue}}" color="{{formColor}}" bindchange="bindSwitchChange" data-type="disableRotate" class="tools-switch" />
         </view>
     </view>
 </view>

--- a/src/image-clipper/index.less
+++ b/src/image-clipper/index.less
@@ -120,7 +120,7 @@
             padding: 20rpx 40rpx;
             box-sizing: border-box;
             
-            image {
+            &-image {
                 display: block;
                 width: 50rpx;
                 height: 50rpx;

--- a/src/image-clipper/index.wxml
+++ b/src/image-clipper/index.wxml
@@ -56,11 +56,11 @@
         <!-- 底部工具栏容器 -->
         <view class="footer-tools">
             <view class="tools-icon">
-                <image src="{{checkImageIcon}}" mut-bind:tap="uploadImage" wx:if="{{checkImage}}" />
-                <image src="{{rotateAlongIcon}}" mut-bind:tap="rotate" data-type="along" wx:if="{{rotateAlong}}" />
-                <image src="{{rotateInverseIcon}}" mut-bind:tap="rotate" data-type="inverse" wx:if="{{rotateInverse}}" />
-                <image src="{{sureIcon}}" mut-bind:tap="getImageData" wx:if="{{sure}}" />
-                <image src="{{closeIcon}}" mut-bind:tap="close" wx:if="{{close}}" />
+                <image src="{{checkImageIcon}}" mut-bind:tap="uploadImage" wx:if="{{checkImage}}" class="tools-icon-image" />
+                <image src="{{rotateAlongIcon}}" mut-bind:tap="rotate" data-type="along" wx:if="{{rotateAlong}}" class="tools-icon-image" />
+                <image src="{{rotateInverseIcon}}" mut-bind:tap="rotate" data-type="inverse" wx:if="{{rotateInverse}}" class="tools-icon-image" />
+                <image src="{{sureIcon}}" mut-bind:tap="getImageData" wx:if="{{sure}}" class="tools-icon-image" />
+                <image src="{{closeIcon}}" mut-bind:tap="close" wx:if="{{close}}" class="tools-icon-image" />
             </view>
             <slot></slot>
         </view>


### PR DESCRIPTION
解决 Some selectors are not allowed in component wxss, including tag name selectors, ID selectors, and attribute selectors. 警告。