### PR TITLE
fix(build/until.js): 修复 forParams() 函数对组件的内置组件的处理

### DIFF
--- a/build/until.js
+++ b/build/until.js
@@ -15,16 +15,27 @@ const forParams = (arr) => {
   arr.map(item => {
     let data = fs.readFileSync(`../src/${item}/index.json`, 'utf-8');
     const params = JSON.parse(data);
-    const { usingComponents } = params;
+    const {
+      usingComponents
+    } = params;
     if (usingComponents && !isEmptyObj(usingComponents)) {
-      for (let key in usingComponents) {
-        let keyComponent = key.substring(2, key.length);
-        finishArr.push(keyComponent);
+      for (let [key, path] of Object.entries(usingComponents)) {
+        if (key.startsWith('l-')) {
+          key = key.substring(2, key.length);
+        } else {
+          key = formatKeyByPath(path, item);
+        }
+        finishArr.push(key);
       }
       componentArr.push(...finishArr);
       forParams(finishArr);
     }
   });
+};
+
+const formatKeyByPath = (path, parent) => {
+  path = path.startsWith('./') ? path.replace('./', '').replace('/index', '') : path.replace('/index', '');
+  return parent + '/' + path;
 };
 
 const isEmptyObj = (obj) => {


### PR DESCRIPTION
按需加载 Calendar 组件时，无法正确构建出 Calendar 组件的内置 Components 文件夹及其内容。
更改了 forParams() 对其他 lin-ui 组件和内置组件的判断，以及对内置组件路径的处理。
更改后能正确按需加载 Calendar 组件的内置 Components 文件夹及其内容。

Close #1398