### PR TITLE
fix(List): 修正 badgePosition 默认值为right

### DIFF
--- a/src/list/index.js
+++ b/src/list/index.js
@@ -60,7 +60,7 @@ Component({
     tagPlain: Boolean,
     badgePosition: {
       type: String,
-      value: 'left'
+      value: 'right'
     },
     dotBadge: Boolean,
     badgeCount: Number,


### PR DESCRIPTION
[fix(List): 修正 badgePosition 默认值为right, 官网示例中 badgePosition 默认值为right，但代码中为left